### PR TITLE
feat: Implement apple selection functionality

### DIFF
--- a/src/components/Grid.css
+++ b/src/components/Grid.css
@@ -18,3 +18,16 @@
   font-family: sans-serif;
   box-sizing: border-box; /* Ensures padding and border don't increase the cell size */
 }
+
+/* 추가될 스타일 */
+.selected-apple {
+  background-color: #a0e0ff; /* 밝은 파란색 배경 */
+  border: 1px solid #007bff; /* 파란색 테두리 */
+  /* 필요에 따라 다른 스타일 추가 가능 (예: box-shadow) */
+}
+
+.sum-display {
+  margin-top: 10px;
+  font-weight: bold;
+  text-align: center; /* Center the text */
+}

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,8 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react'; // Added useRef
 import './Grid.css';
 
 interface GridProps {
   // Props will be defined later
+}
+
+// 셀의 좌표를 나타내는 인터페이스
+interface CellPosition {
+  row: number;
+  col: number;
+}
+
+// 선택된 사과 정보를 나타내는 인터페이스
+interface SelectedApple extends CellPosition {
+  value: number;
 }
 
 const GRID_SIZE = 10;
@@ -21,34 +32,148 @@ const initializeGrid = (): number[][] => {
   return newGrid;
 };
 
+// Helper function to get cell coordinates from mouse event relative to the grid
+const getCellCoordsFromEvent = (event: React.MouseEvent<HTMLDivElement>, gridRef: HTMLDivElement | null): CellPosition | null => {
+  if (!gridRef) return null;
+
+  const rect = gridRef.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+
+  // Assuming square cells and no margins/padding within the grid container affecting cell positioning
+  // These cell dimensions should ideally come from dynamic calculation or props if they can vary
+  const cellWidth = gridRef.offsetWidth / GRID_SIZE;
+  const cellHeight = gridRef.offsetHeight / GRID_SIZE;
+
+  const col = Math.floor(x / cellWidth);
+  const row = Math.floor(y / cellHeight);
+
+  if (row >= 0 && row < GRID_SIZE && col >= 0 && col < GRID_SIZE) {
+    return { row, col };
+  }
+  return null;
+};
+
+
 const Grid: React.FC<GridProps> = () => {
   const [gridData, setGridData] = useState<number[][]>([]);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [dragStartCell, setDragStartCell] = useState<CellPosition | null>(null);
+  const [dragCurrentCell, setDragCurrentCell] = useState<CellPosition | null>(null); // dragCurrentCell is kept for potential future use, though not directly used in selection logic in this version
+  const [selectedApples, setSelectedApples] = useState<SelectedApple[]>([]);
+  const [currentSum, setCurrentSum] = useState<number>(0);
+  const gridRef = useRef<HTMLDivElement>(null); // Ref for the grid container
 
   useEffect(() => {
     setGridData(initializeGrid());
   }, []);
 
+  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    // Check if the click is on a grid cell directly, not on the scrollbars or edges of grid-container
+    const target = event.target as HTMLElement;
+    if (!target.classList.contains('grid-cell') && !target.classList.contains('grid-container')) {
+        // If the click is not on a cell or the container itself, but maybe on a scrollbar, ignore.
+        // This check can be refined. For now, we allow starting drag from container for simplicity with getCellCoordsFromEvent.
+    }
+
+    const coords = getCellCoordsFromEvent(event, gridRef.current);
+    if (coords) {
+      setIsDragging(true);
+      setDragStartCell(coords);
+      setSelectedApples([{ row: coords.row, col: coords.col, value: gridData[coords.row][coords.col] }]); // Select starting cell
+      setCurrentSum(gridData[coords.row][coords.col]); // Set sum for the starting cell
+      setDragCurrentCell(coords);
+    }
+  };
+
+  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!isDragging || !dragStartCell) return;
+
+    const currentCoords = getCellCoordsFromEvent(event, gridRef.current);
+    if (currentCoords) {
+      // Optimization: only update if current cell changes
+      if (dragCurrentCell && currentCoords.row === dragCurrentCell.row && currentCoords.col === dragCurrentCell.col) {
+        return;
+      }
+      setDragCurrentCell(currentCoords);
+
+      const newSelectedApples: SelectedApple[] = [];
+      const minRow = Math.min(dragStartCell.row, currentCoords.row);
+      const maxRow = Math.max(dragStartCell.row, currentCoords.row);
+      const minCol = Math.min(dragStartCell.col, currentCoords.col);
+      const maxCol = Math.max(dragStartCell.col, currentCoords.col);
+
+      for (let r = minRow; r <= maxRow; r++) {
+        for (let c = minCol; c <= maxCol; c++) {
+          if (gridData[r] && gridData[r][c] !== undefined) {
+            newSelectedApples.push({ row: r, col: c, value: gridData[r][c] });
+          }
+        }
+      }
+      setSelectedApples(newSelectedApples);
+      // Optional: Calculate sum in real-time during drag
+      // const sum = newSelectedApples.reduce((acc, apple) => acc + apple.value, 0);
+      // setCurrentSum(sum);
+    }
+  };
+
+  const handleMouseUp = () => {
+    if (!isDragging) return;
+    setIsDragging(false);
+
+    const sum = selectedApples.reduce((acc, apple) => acc + apple.value, 0);
+    setCurrentSum(sum);
+
+    // console.log("Selected Apples:", selectedApples);
+    // console.log("Current Sum:", sum);
+
+    // Reset dragStartCell and dragCurrentCell if you want selection to clear,
+    // or keep them to allow sum-checking logic to proceed with current selection.
+    // For this task, we'll keep them until next mousedown.
+    // setDragStartCell(null);
+    // setDragCurrentCell(null);
+  };
+
+  // Render logic
   const cells = [];
-  for (let i = 0; i < gridData.length; i++) {
-    for (let j = 0; j < gridData[i].length; j++) {
-      cells.push(
-        <div
-          key={`${i}-${j}`}
-          className="grid-cell"
-        >
-          {gridData[i][j]}
-        </div>
-      );
+  if (gridData.length > 0) { // Ensure gridData is loaded
+    for (let i = 0; i < GRID_SIZE; i++) {
+      for (let j = 0; j < GRID_SIZE; j++) {
+        const isSelected = selectedApples.some(apple => apple.row === i && apple.col === j);
+        cells.push(
+          <div
+            key={`${i}-${j}`}
+            className={`grid-cell ${isSelected ? 'selected-apple' : ''}`}
+            data-row={i}
+            data-col={j}
+          >
+            {gridData[i][j]}
+          </div>
+        );
+      }
     }
   }
 
+
   if (gridData.length === 0) {
-    return <div>Loading Grid...</div>; // Or some other loading indicator
+    return <div>Loading Grid...</div>;
   }
 
   return (
-    <div className="grid-container">
-      {cells}
+    <div>
+      <div
+        ref={gridRef} // Attach ref here
+        className="grid-container"
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp} // End drag if mouse leaves grid
+      >
+        {cells}
+      </div>
+      <div className="sum-display">
+        <p>Current Sum: {currentSum}</p>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This commit introduces the following features:

- **Drag-to-Select:** You can now select a rectangular area of apples on the grid by clicking and dragging the mouse.
- **Sum Calculation:** The sum of the numbers on the selected apples is calculated and displayed below the grid when the mouse button is released.
- **Visual Highlight:** Selected apples are visually highlighted with a different background color and border.

Implemented in `src/components/Grid.tsx` by:
- Adding state variables to manage drag state, selected apples, and the current sum.
- Implementing mouse event handlers (`handleMouseDown`, `handleMouseMove`, `handleMouseUp`, `handleMouseLeave`) for the grid container.
- Calculating cell coordinates from mouse events.
- Dynamically updating the list of selected apples based on the drag area.
- Applying a CSS class (`.selected-apple`) to highlight selected cells.
- Displaying the `currentSum` below the grid.