### PR TITLE
Refactor: 시작/종료 화면 UX 개선 (한국어 요청사항 반영)

### DIFF
--- a/src/components/GameOverScreen.css
+++ b/src/components/GameOverScreen.css
@@ -43,34 +43,92 @@
   color: white;
 }
 
-.save-score-section {
+/* Container for score saving UI elements */
+.save-score-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   margin: 20px 0;
-  display: flex; /* Align input and button horizontally */
-  align-items: center; /* Vertically align items in the center */
-  justify-content: center; /* Horizontally center items if they don't fill the width */
-  gap: 10px; /* Space between input and button */
+  width: 80%;
+  max-width: 400px; /* Max width for the save score area */
 }
 
-.player-name-input {
+.save-score-section {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%; /* Take full width of parent .save-score-container */
+}
+
+.save-score-section input[type="text"] {
   padding: 10px;
   font-size: 1rem;
   border: 1px solid #ccc;
   border-radius: 4px;
-  color: #333; /* 입력 텍스트 색상 추가 */
+  color: #333;
+  flex-grow: 1; /* Allow input to take available space */
 }
 
-.save-score-button {
+.save-score-section input[type="text"]:disabled {
+  background-color: #eee;
+  cursor: not-allowed;
+}
+
+.save-score-section button {
   padding: 10px 20px;
   font-size: 1rem;
   cursor: pointer;
-  background-color: #007bff; /* 파란색 계열 */
+  background-color: #007bff;
   color: white;
   border: none;
   border-radius: 5px;
 }
 
-.save-score-button:hover {
+.save-score-section button:hover {
   background-color: #0056b3;
+}
+
+.save-score-section button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.save-status-message {
+  margin-top: 15px;
+  font-size: 1rem;
+  padding: 10px;
+  border-radius: 5px;
+  width: 100%; /* Make message take full width of container */
+  box-sizing: border-box; /* Include padding in width */
+  text-align: center;
+}
+
+.save-status-message.success {
+  background-color: #28a745; /* Green for success */
+  color: white;
+}
+
+.save-status-message.error {
+  background-color: #dc3545; /* Red for error */
+  color: white;
+}
+
+.save-status-message.info {
+  background-color: #17a2b8; /* Blue for info (like 'Saving...') */
+  color: white;
+}
+
+.score-display-after-save {
+  margin-top: 10px; /* Or use .save-status-message margin */
+  font-size: 1.2rem;
+  color: #fff; /* White text */
+  padding: 10px;
+  background-color: rgba(255, 255, 255, 0.1); /* Subtle background */
+  border-radius: 5px;
+  text-align: center;
+  width: 100%; /* Make it take full width of parent */
+  box-sizing: border-box;
 }
 
 @media (max-width: 768px) {
@@ -106,20 +164,30 @@
     font-size: 1.1rem; /* Adjust font size */
   }
 
+  .save-score-container {
+    width: 90%; /* Wider container on small screens */
+  }
+
   .save-score-section {
     flex-direction: column; /* Stack input and button on smaller screens */
-    width: 80%; /* Match button width for consistency */
-    margin-left: auto; /* Center the section */
-    margin-right: auto; /* Center the section */
+    /* width: 100%; */ /* Already set to 100% of parent */
   }
 
-  .player-name-input {
-    width: 100%; /* Full width within its container */
-    margin-bottom: 10px; /* Space when stacked */
-    box-sizing: border-box; /* Ensure padding doesn't add to width */
+  .save-score-section input[type="text"] {
+    width: 100%;
+    margin-bottom: 10px;
+    box-sizing: border-box;
   }
 
-  .save-score-button {
-    width: 100%; /* Full width button */
+  .save-score-section button {
+    width: 100%;
+  }
+
+  .save-status-message {
+    font-size: 0.9rem;
+  }
+
+  .score-display-after-save {
+    font-size: 1.1rem;
   }
 }

--- a/src/components/GameOverScreen.tsx
+++ b/src/components/GameOverScreen.tsx
@@ -10,6 +10,8 @@ interface GameOverScreenProps {
 const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMainMenu }) => {
   const [highScore, setHighScore] = useState(0);
   const [playerName, setPlayerName] = useState('');
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [isScoreSaved, setIsScoreSaved] = useState<boolean>(false);
 
   useEffect(() => {
     const storedHighScore = localStorage.getItem('appleCollectorHighScore');
@@ -26,8 +28,12 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
   }, [score, highScore]);
 
   const handleSaveScore = async () => {
+    setSaveMessage('저장 중...');
+    setIsScoreSaved(false);
+
     if (!playerName.trim()) {
-      alert('이름을 입력해주세요!');
+      setSaveMessage('이름을 입력해주세요!');
+      // setIsScoreSaved is already false
       return;
     }
 
@@ -56,9 +62,8 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
 
     try {
       localStorage.setItem('appleCollectorRankings', JSON.stringify(top10Rankings));
-      // 로컬 저장 성공 알림은 CouchDB 결과 후 한 번에 처리하거나, 여기서 일단 유지하고 CouchDB 실패 시 추가 알림
-      // alert('점수가 로컬에 저장되었습니다!');
-      setPlayerName(''); // Clear player name after saving, do this regardless of CouchDB result for now
+      // PlayerName is not cleared here anymore to display it after saving.
+      // setPlayerName('');
 
       // Send to CouchDB
       const couchDbUrl = 'http://couchdb.ioplug.net/scoredb';
@@ -81,21 +86,24 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
         });
 
         if (response.ok) {
-          // console.log('Score successfully saved to CouchDB:', await response.json()); // 주석 처리
-          alert('점수가 로컬 및 온라인 랭킹에 모두 저장되었습니다!');
+          setSaveMessage(`${playerName}님의 점수: ${score}점이 로컬 및 온라인 랭킹에 모두 저장되었습니다!`);
+          setIsScoreSaved(true);
         } else {
-          const errorData = await response.text(); // Use text() in case response is not JSON
+          const errorData = await response.text();
           console.error('Failed to save score to CouchDB:', response.status, errorData);
-          alert(`로컬에는 점수가 저장되었지만, 온라인 랭킹 저장에 실패했습니다. (서버 응답: ${response.status})`);
+          setSaveMessage(`${playerName}님의 점수: ${score}점이 로컬에는 저장되었지만, 온라인 랭킹 저장에 실패했습니다. (서버 응답: ${response.status})`);
+          setIsScoreSaved(true); // Local save was successful
         }
       } catch (networkError) {
         console.error('Network error when trying to save score to CouchDB:', networkError);
-        alert(`로컬에는 점수가 저장되었지만, 온라인 랭킹 저장 중 네트워크 오류가 발생했습니다.`);
+        setSaveMessage(`${playerName}님의 점수: ${score}점이 로컬에는 저장되었지만, 온라인 랭킹 저장 중 네트워크 오류가 발생했습니다.`);
+        setIsScoreSaved(true); // Local save was successful
       }
 
     } catch (error) {
       console.error("Error saving rankings to localStorage", error);
-      alert('로컬 점수 저장 중 오류가 발생했습니다.');
+      setSaveMessage('로컬 점수 저장 중 오류가 발생했습니다.');
+      setIsScoreSaved(false);
     }
   };
 
@@ -106,21 +114,36 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
         <p>Your Score: {score}</p>
         <p>High Score: {highScore}</p>
       </div>
-      <div className="save-score-section" style={{ margin: '20px 0' }}>
-        <input
-          type="text"
-          placeholder="이름을 입력하세요"
-          value={playerName}
-          onChange={(e) => setPlayerName(e.target.value)}
-          style={{ padding: '10px', marginRight: '10px', fontSize: '1rem' }}
-        />
-        <button
-          onClick={handleSaveScore} // Directly use the async function
-          style={{ padding: '10px 20px', fontSize: '1rem', cursor: 'pointer' }}
-        >
-          점수 저장
-        </button>
+
+      <div className="save-score-container">
+        {isScoreSaved ? (
+          <div className="score-display-after-save">
+            {playerName}님의 점수: {score}
+          </div>
+        ) : (
+          <div className="save-score-section">
+            <input
+              type="text"
+              placeholder="이름을 입력하세요"
+              value={playerName}
+              onChange={(e) => setPlayerName(e.target.value)}
+              disabled={isScoreSaved}
+            />
+            <button
+              onClick={handleSaveScore}
+              disabled={isScoreSaved}
+            >
+              점수 저장
+            </button>
+          </div>
+        )}
+        {saveMessage && (
+          <p className={`save-status-message ${isScoreSaved ? 'success' : (!playerName.trim() && saveMessage === '이름을 입력해주세요!' ? 'error' : (saveMessage.includes('오류') || saveMessage.includes('실패') ? 'error' : 'info'))}`}>
+            {saveMessage}
+          </p>
+        )}
       </div>
+
       <div className="buttons">
         <button onClick={onRestart} className="restart-button">
           Restart Game

--- a/src/components/StartScreen.css
+++ b/src/components/StartScreen.css
@@ -50,3 +50,77 @@
     font-size: 1.1rem; /* Adjust font size for mobile */
   }
 }
+
+/* Styles for the inline leaderboard */
+.leaderboard-container-inline {
+  margin-top: 30px;
+  width: 80%;
+  max-width: 600px;
+  background-color: rgba(255, 255, 255, 0.1); /* Slightly transparent background */
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.leaderboard-container-inline h2 {
+  margin-bottom: 15px;
+  color: #fff;
+}
+
+.leaderboard-table-inline {
+  width: 100%;
+  border-collapse: collapse;
+  color: #ddd; /* Light text color for table content */
+}
+
+.leaderboard-table-inline th,
+.leaderboard-table-inline td {
+  border: 1px solid #555; /* Darker borders for the table */
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.leaderboard-table-inline th {
+  background-color: #333; /* Dark background for headers */
+  color: #fff;
+}
+
+.leaderboard-table-inline tbody tr:nth-child(odd) {
+  background-color: rgba(255, 255, 255, 0.05); /* Slightly lighter for odd rows */
+}
+
+.leaderboard-table-inline tbody tr:hover {
+  background-color: rgba(255, 255, 255, 0.15); /* Highlight on hover */
+}
+
+.leaderboard-message {
+  margin-top: 10px;
+  font-size: 1.1rem;
+  color: #ccc;
+}
+
+.leaderboard-message.error {
+  color: #ff6b6b; /* A distinct error color */
+  font-weight: bold;
+}
+
+/* Responsive adjustments for the inline leaderboard */
+@media (max-width: 768px) {
+  .leaderboard-container-inline {
+    width: 90%;
+    padding: 15px;
+  }
+
+  .leaderboard-table-inline th,
+  .leaderboard-table-inline td {
+    padding: 6px 8px;
+    font-size: 0.9rem;
+  }
+
+  .leaderboard-container-inline h2 {
+    font-size: 1.5rem;
+  }
+
+  .leaderboard-message {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
- 시작 화면:
  - 리더보드를 팝업 대신 화면 내에 직접 표시하도록 변경
  - 데이터 로딩/오류 메시지를 화면 내에 표시 (alert 제거)
- 종료 화면:
  - 이름 입력 후 점수 저장 시, 결과를 팝업/alert 대신 화면 내 메시지로 표시
  - 저장 성공 시 이름과 점수를 화면에 표시하고 입력 UI 비활성화

이번 변경은 한국어 사용자의 요청에 따라, 별도의 팝업이나 시스템 알림창 없이 게임의 주요 정보를 화면 자체에 자연스럽게 통합하여 사용자 경험을 개선하는 데 중점을 두었습니다.