### PR TITLE
Refactor: 종료 화면 기능 추가 및 UX 개선 (한국어 추가 요청 반영)

### DIFF
--- a/src/components/GameOverScreen.css
+++ b/src/components/GameOverScreen.css
@@ -8,6 +8,7 @@
   text-align: center;
   background-color: rgba(0, 0, 0, 0.8); /* 약간 어두운 배경 */
   color: white;
+  overflow-y: auto; /* Allow scrolling if content exceeds viewport height */
 }
 
 .game-over-screen h1 {
@@ -22,6 +23,7 @@
 
 .buttons {
   margin-top: 30px;
+  margin-bottom: 20px; /* Add some space at the bottom */
 }
 
 .buttons button {
@@ -131,46 +133,95 @@
   box-sizing: border-box;
 }
 
+/* Styles for the inline leaderboard (copied from StartScreen.css) */
+.leaderboard-container-inline {
+  margin-top: 30px;
+  width: 80%;
+  max-width: 600px; /* Same as StartScreen for consistency */
+  background-color: rgba(255, 255, 255, 0.1);
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.leaderboard-container-inline h2 {
+  margin-bottom: 15px;
+  color: #fff;
+}
+
+.leaderboard-table-inline {
+  width: 100%;
+  border-collapse: collapse;
+  color: #ddd;
+}
+
+.leaderboard-table-inline th,
+.leaderboard-table-inline td {
+  border: 1px solid #555;
+  padding: 8px 12px;
+  text-align: left;
+}
+
+.leaderboard-table-inline th {
+  background-color: #333;
+  color: #fff;
+}
+
+.leaderboard-table-inline tbody tr:nth-child(odd) {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.leaderboard-table-inline tbody tr:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.leaderboard-message {
+  margin-top: 10px;
+  font-size: 1.1rem;
+  color: #ccc;
+}
+
+.leaderboard-message.error {
+  color: #ff6b6b;
+  font-weight: bold;
+}
+
+
 @media (max-width: 768px) {
   .game-over-screen {
-    /* Adjust height if 100vh is too much on mobile with browser chrome,
-       or rely on main app container scrolling if that's preferred.
-       For a modal-like screen, 100vh might still be intended. */
-    padding: 20px; /* Add some padding for smaller screens */
-    width: 100vw; /* Make the container span the full viewport width */
-    box-sizing: border-box; /* Ensure padding/border don't add to width */
+    padding: 15px; /* Slightly reduced padding */
+    width: 100vw;
+    box-sizing: border-box;
   }
 
   .game-over-screen h1 {
-    font-size: 2.2rem; /* Reduced font size */
+    font-size: 2.0rem; /* Further reduced for more space */
   }
 
   .score-summary p {
-    font-size: 1.3rem; /* Reduced font size */
+    font-size: 1.2rem; /* Reduced font size */
   }
 
   .buttons {
     display: flex;
-    flex-direction: column; /* Stack buttons */
-    align-items: center; /* Center stacked buttons */
-    gap: 15px; /* Space between stacked buttons */
-    width: 100%; /* Ensure buttons container takes width */
+    flex-direction: column;
+    align-items: center;
+    gap: 10px; /* Reduced gap */
+    width: 100%;
   }
 
   .buttons button {
-    width: 80%; /* Set width for stacked buttons */
-    margin: 0; /* Remove horizontal margins */
-    padding: 12px 15px; /* Adjust padding */
-    font-size: 1.1rem; /* Adjust font size */
+    width: 70%; /* Slightly reduced width */
+    margin: 0;
+    padding: 10px 12px; /* Adjust padding */
+    font-size: 1.0rem; /* Adjust font size */
   }
 
   .save-score-container {
-    width: 90%; /* Wider container on small screens */
+    width: 90%;
   }
 
   .save-score-section {
-    flex-direction: column; /* Stack input and button on smaller screens */
-    /* width: 100%; */ /* Already set to 100% of parent */
+    flex-direction: column;
   }
 
   .save-score-section input[type="text"] {
@@ -189,5 +240,26 @@
 
   .score-display-after-save {
     font-size: 1.1rem;
+  }
+
+  /* Responsive adjustments for the inline leaderboard (copied from StartScreen.css) */
+  .leaderboard-container-inline {
+    width: 90%; /* Match other containers on small screens */
+    padding: 15px;
+    margin-top: 20px; /* Adjust margin */
+  }
+
+  .leaderboard-table-inline th,
+  .leaderboard-table-inline td {
+    padding: 6px 8px;
+    font-size: 0.85rem; /* Slightly smaller for game over screen */
+  }
+
+  .leaderboard-container-inline h2 {
+    font-size: 1.3rem; /* Slightly smaller */
+  }
+
+  .leaderboard-message {
+    font-size: 0.9rem; /* Match other messages */
   }
 }

--- a/src/components/GameOverScreen.tsx
+++ b/src/components/GameOverScreen.tsx
@@ -1,6 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import './GameOverScreen.css'; // CSS 파일도 생성 예정
 
+// Copied from StartScreen.tsx
+interface ScoreEntry {
+  id: string;
+  key: number;
+  value: {
+    name: string;
+    createdAt?: string;
+  };
+}
+
 interface GameOverScreenProps {
   score: number;
   onRestart: () => void;
@@ -13,29 +23,44 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [isScoreSaved, setIsScoreSaved] = useState<boolean>(false);
 
-  useEffect(() => {
-    const storedHighScore = localStorage.getItem('appleCollectorHighScore');
-    if (storedHighScore) {
-      setHighScore(parseInt(storedHighScore, 10));
-    }
-  }, []);
+  // Leaderboard states - Copied from StartScreen.tsx
+  const [leaderboardData, setLeaderboardData] = useState<ScoreEntry[]>([]);
+  const [leaderboardError, setLeaderboardError] = useState<string | null>(null);
+  const [isLoadingLeaderboard, setIsLoadingLeaderboard] = useState<boolean>(false);
 
+  // This useEffect is now only for updating the *local* personal best.
+  // The displayed highScore state is set by handleFetchLeaderboard.
   useEffect(() => {
-    if (score > highScore) {
+    const localHighScoreString = localStorage.getItem('appleCollectorHighScore');
+    const localHighScore = localHighScoreString ? parseInt(localHighScoreString, 10) : 0;
+    if (score > localHighScore) {
       localStorage.setItem('appleCollectorHighScore', score.toString());
-      setHighScore(score);
     }
-  }, [score, highScore]);
+    // We no longer set the highScore state here based on the current game's score directly.
+    // It's updated via fetching leaderboard data.
+  }, [score]); // Only depends on score
+
+  // Load player name from localStorage on mount
+  useEffect(() => {
+    const storedName = localStorage.getItem('lastPlayerName');
+    if (storedName) {
+      setPlayerName(storedName);
+    }
+  }, []); // Empty dependency array ensures this runs only once on mount
 
   const handleSaveScore = async () => {
     setSaveMessage('저장 중...');
     setIsScoreSaved(false);
 
-    if (!playerName.trim()) {
+    const trimmedPlayerName = playerName.trim();
+    if (!trimmedPlayerName) {
       setSaveMessage('이름을 입력해주세요!');
       // setIsScoreSaved is already false
       return;
     }
+
+    // Save player name to localStorage
+    localStorage.setItem('lastPlayerName', trimmedPlayerName);
 
     const rankingsString = localStorage.getItem('appleCollectorRankings');
     let rankings = [];
@@ -51,7 +76,7 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
       }
     }
 
-    const newScoreEntry = { name: playerName, score: score };
+    const newScoreEntry = { name: trimmedPlayerName, score: score };
     rankings.push(newScoreEntry);
 
     // Sort by score descending
@@ -69,7 +94,7 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
       const couchDbUrl = 'http://couchdb.ioplug.net/scoredb';
       const scoreDataForDb = {
         type: 'score',
-        name: playerName,
+        name: trimmedPlayerName, // Use trimmed name for saving to DB
         score: score,
         createdAt: new Date().toISOString(),
       };
@@ -86,17 +111,17 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
         });
 
         if (response.ok) {
-          setSaveMessage(`${playerName}님의 점수: ${score}점이 로컬 및 온라인 랭킹에 모두 저장되었습니다!`);
+          setSaveMessage(`${trimmedPlayerName}님의 점수: ${score}점이 로컬 및 온라인 랭킹에 모두 저장되었습니다!`);
           setIsScoreSaved(true);
         } else {
           const errorData = await response.text();
           console.error('Failed to save score to CouchDB:', response.status, errorData);
-          setSaveMessage(`${playerName}님의 점수: ${score}점이 로컬에는 저장되었지만, 온라인 랭킹 저장에 실패했습니다. (서버 응답: ${response.status})`);
+          setSaveMessage(`${trimmedPlayerName}님의 점수: ${score}점이 로컬에는 저장되었지만, 온라인 랭킹 저장에 실패했습니다. (서버 응답: ${response.status})`);
           setIsScoreSaved(true); // Local save was successful
         }
       } catch (networkError) {
         console.error('Network error when trying to save score to CouchDB:', networkError);
-        setSaveMessage(`${playerName}님의 점수: ${score}점이 로컬에는 저장되었지만, 온라인 랭킹 저장 중 네트워크 오류가 발생했습니다.`);
+        setSaveMessage(`${trimmedPlayerName}님의 점수: ${score}점이 로컬에는 저장되었지만, 온라인 랭킹 저장 중 네트워크 오류가 발생했습니다.`);
         setIsScoreSaved(true); // Local save was successful
       }
 
@@ -105,7 +130,63 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
       setSaveMessage('로컬 점수 저장 중 오류가 발생했습니다.');
       setIsScoreSaved(false);
     }
+    // After saving, fetch the leaderboard again to show the latest scores
+    handleFetchLeaderboard();
   };
+
+  // handleFetchLeaderboard - Copied and adapted from StartScreen.tsx
+  const handleFetchLeaderboard = async () => {
+    setIsLoadingLeaderboard(true);
+    setLeaderboardError(null);
+    const url = 'http://couchdb.ioplug.net/scoredb/_design/scores/_view/by_score?descending=true&limit=10';
+
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Basic ${btoa('user1:any')}`,
+        }
+      });
+      if (!response.ok) {
+        const errorMsgText = await response.text();
+        let errorDetail = "";
+        try {
+          const errorData = JSON.parse(errorMsgText);
+          errorDetail = ` - ${errorData.reason || errorData.error || errorMsgText}`;
+        } catch (e) {
+          errorDetail = ` - ${errorMsgText.substring(0, 100)}`;
+        }
+        throw new Error(`Failed to fetch leaderboard: ${response.status}${errorDetail}`);
+      }
+      const data = await response.json();
+      const fetchedRows = data.rows || [];
+      setLeaderboardData(fetchedRows);
+
+      if (fetchedRows.length > 0) {
+        // Scores are in entry.key
+        const maxScore = fetchedRows.reduce((max: number, entry: ScoreEntry) => entry.key > max ? entry.key : max, 0);
+        setHighScore(maxScore);
+      } else {
+        setHighScore(0); // No scores on the leaderboard
+      }
+    } catch (error) {
+      console.error("Error fetching leaderboard:", error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setLeaderboardError(`Could not load leaderboard data. Error: ${errorMessage}`);
+      setLeaderboardData([]);
+      setHighScore(0); // Set high score to 0 on error
+    } finally {
+      setIsLoadingLeaderboard(false);
+    }
+  };
+
+  // Fetch leaderboard when component mounts
+  useEffect(() => {
+    handleFetchLeaderboard();
+    // The dependency array is empty, so this runs once on mount.
+  }, []);
+
 
   return (
     <div className="game-over-screen">
@@ -141,6 +222,38 @@ const GameOverScreen: React.FC<GameOverScreenProps> = ({ score, onRestart, onMai
           <p className={`save-status-message ${isScoreSaved ? 'success' : (!playerName.trim() && saveMessage === '이름을 입력해주세요!' ? 'error' : (saveMessage.includes('오류') || saveMessage.includes('실패') ? 'error' : 'info'))}`}>
             {saveMessage}
           </p>
+        )}
+      </div>
+
+      {/* Leaderboard Section - Copied and adapted from StartScreen.tsx */}
+      <div className="leaderboard-container-inline">
+        <h2>Leaderboard</h2>
+        {isLoadingLeaderboard && <p className="leaderboard-message">Loading leaderboard...</p>}
+        {leaderboardError && <p className="leaderboard-message error">{leaderboardError}</p>}
+        {!isLoadingLeaderboard && !leaderboardError && leaderboardData.length === 0 && (
+          <p className="leaderboard-message">No scores yet...</p>
+        )}
+        {!isLoadingLeaderboard && !leaderboardError && leaderboardData.length > 0 && (
+          <table className="leaderboard-table-inline">
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Name</th>
+                <th>Score</th>
+                <th>Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leaderboardData.map((scoreEntry, index) => (
+                <tr key={scoreEntry.id || index}>
+                  <td>{index + 1}</td>
+                  <td>{scoreEntry.value.name}</td>
+                  <td>{scoreEntry.key}</td>
+                  <td>{scoreEntry.value.createdAt ? new Date(scoreEntry.value.createdAt).toLocaleDateString() : 'N/A'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         )}
       </div>
 


### PR DESCRIPTION
- 종료 화면 (`GameOverScreen.tsx`):
  - 화면 내 리더보드 표시 기능 추가 (시작 화면과 유사)
  - 점수 저장 시 리더보드 자동 새로고침 기능 추가
  - "High Score"를 로컬 저장소 대신 리더보드의 실제 최고 점수로 표시하도록 변경
  - 사용자 이름 기억 기능 추가: 마지막으로 입력한 이름을 다음 게임에 자동으로 채워줌

- 기존 변경 사항 유지:
  - 시작 화면: 리더보드 화면 내 직접 표시, alert 제거
  - 종료 화면: 점수 저장 결과 화면 내 메시지 표시, alert 제거

이번 변경은 이전에 진행된 UX 개선에 더하여, 종료 화면의 기능을 확장하고 사용자 편의성을 높이는 추가 요청사항을 반영하였습니다.